### PR TITLE
Rename zh_Hans.po to zh_CN.po

### DIFF
--- a/LINGUAS
+++ b/LINGUAS
@@ -29,4 +29,4 @@ tr
 ar
 uk
 kn
-zh_Hans
+zh_CN

--- a/zh_CN.po
+++ b/zh_CN.po
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Chinese (simplified) translation of the Dialect app for GNOME.
+# Copyright (C) Dialect authors and many contributors.
 # This file is distributed under the same license as the dialect package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Zhong Lufan <lufanzhong@gmail.com>, 2021.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
Weblate automatically names Chinese Simplified as `zh_Hans`, but it does not conform to the gettext naming specification.